### PR TITLE
fix: broken parsing logic

### DIFF
--- a/src/renderer/src/components/Dialogs/ConnectionDialog.tsx
+++ b/src/renderer/src/components/Dialogs/ConnectionDialog.tsx
@@ -181,7 +181,6 @@ export function ConnectionDialog(): JSX.Element {
     setTestResult(null)
     try {
       const effective = getEffectiveForm()
-      console.log('[handleTest] tab:', tab, 'connStr:', connStr, 'form.username:', form.username, 'effective.username:', effective.username)
       const result = await window.api.connections.test({
         host: effective.host,
         port: parseInt(effective.port) || 5432,


### PR DESCRIPTION
without this change, my planetscale connection string incorrectly parses as localhost, rather than the correct planetscale host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can input raw database connection strings directly.
  * Typed connection strings in the Fields view are detected, parsed, and auto-populate the form.
  * UI auto-switches between manual fields and connection string modes for a smoother flow.
  * Tests and saves use the merged/active connection data (including SSL and colors) after parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->