### PR TITLE
feat: add saved queries

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { registerQueryHandlers } from './ipc/query'
 import { registerSchemaHandlers } from './ipc/schema'
 import { registerExportHandlers } from './ipc/export'
 import { registerHistoryHandlers } from './ipc/history'
+import { registerSavedQueriesHandlers } from './ipc/savedQueries'
 import { registerSettingsHandlers, applyStoredTheme } from './ipc/settings'
 import { buildAppMenu } from './menu'
 import { disconnectAll } from './db/client'
@@ -71,6 +72,7 @@ app.whenReady().then(() => {
   registerSchemaHandlers()
   registerExportHandlers()
   registerHistoryHandlers()
+  registerSavedQueriesHandlers()
   registerSettingsHandlers()
 
   createWindow()

--- a/src/main/ipc/savedQueries.ts
+++ b/src/main/ipc/savedQueries.ts
@@ -1,0 +1,55 @@
+import { ipcMain } from 'electron'
+import { randomUUID } from 'crypto'
+import { store, type SavedQuery } from '../store'
+
+export function registerSavedQueriesHandlers(): void {
+  ipcMain.handle('savedQueries:list', (_e, connectionId?: string | null) => {
+    const queries = store.get('savedQueries')
+    if (connectionId) {
+      return queries.filter((q) => q.connectionId === connectionId || q.connectionId === null)
+    }
+    return queries
+  })
+
+  ipcMain.handle(
+    'savedQueries:save',
+    (_e, payload: { id?: string; name: string; sql: string; connectionId?: string | null }) => {
+      const queries = store.get('savedQueries')
+      const now = Date.now()
+
+      if (payload.id) {
+        const idx = queries.findIndex((q) => q.id === payload.id)
+        if (idx < 0) {
+          throw new Error(`Saved query not found: ${payload.id}`)
+        }
+        const updated: SavedQuery = {
+          ...queries[idx],
+          name: payload.name,
+          sql: payload.sql,
+          connectionId: payload.connectionId ?? null,
+          updatedAt: now
+        }
+        const next = [...queries]
+        next[idx] = updated
+        store.set('savedQueries', next)
+        return updated
+      }
+
+      const newQuery: SavedQuery = {
+        id: randomUUID(),
+        name: payload.name,
+        sql: payload.sql,
+        connectionId: payload.connectionId ?? null,
+        createdAt: now,
+        updatedAt: now
+      }
+      store.set('savedQueries', [newQuery, ...queries])
+      return newQuery
+    }
+  )
+
+  ipcMain.handle('savedQueries:delete', (_e, id: string) => {
+    const queries = store.get('savedQueries').filter((q) => q.id !== id)
+    store.set('savedQueries', queries)
+  })
+}

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -24,6 +24,15 @@ export interface QueryHistoryEntry {
   rowCount?: number
 }
 
+export interface SavedQuery {
+  id: string
+  name: string
+  sql: string
+  connectionId: string | null
+  createdAt: number
+  updatedAt: number
+}
+
 export interface AppSettings {
   theme: 'auto' | 'dark' | 'light'
   editorFontSize: number
@@ -38,6 +47,7 @@ export interface SessionTab {
   mode: 'query' | 'table'
   tableMeta: { schema: string; table: string; connectionId: string } | null
   connectionId: string | null
+  savedQueryId?: string | null
 }
 
 export interface SessionState {
@@ -49,6 +59,7 @@ export interface SessionState {
 interface StoreSchema {
   connections: SavedConnection[]
   queryHistory: QueryHistoryEntry[]
+  savedQueries: SavedQuery[]
   settings: AppSettings
   session: SessionState
 }
@@ -58,6 +69,7 @@ export const store = new Store<StoreSchema>({
   defaults: {
     connections: [],
     queryHistory: [],
+    savedQueries: [],
     settings: {
       theme: 'auto',
       editorFontSize: 13,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -77,6 +77,7 @@ export interface SessionTab {
   mode: 'query' | 'table'
   tableMeta: { schema: string; table: string; connectionId: string } | null
   connectionId: string | null
+  savedQueryId?: string | null
 }
 
 export interface SessionState {
@@ -181,6 +182,17 @@ const api = {
       ipcRenderer.invoke('history:list', connectionId),
     clear: (connectionId?: string): Promise<void> =>
       ipcRenderer.invoke('history:clear', connectionId)
+  },
+  savedQueries: {
+    list: (connectionId?: string | null) =>
+      ipcRenderer.invoke('savedQueries:list', connectionId),
+    save: (payload: {
+      id?: string
+      name: string
+      sql: string
+      connectionId?: string | null
+    }) => ipcRenderer.invoke('savedQueries:save', payload),
+    delete: (id: string) => ipcRenderer.invoke('savedQueries:delete', id)
   },
   session: {
     get: (): Promise<SessionState> => ipcRenderer.invoke('session:get'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { cn } from './lib/utils'
 import { useAppStore } from './store/useAppStore'
 import { ConnectionList } from './components/Sidebar/ConnectionList'
 import { SchemaTree } from './components/Sidebar/SchemaTree'
+import { SavedQueriesPanel } from './components/Sidebar/SavedQueriesPanel'
 import { TitleBar } from './components/TitleBar/TitleBar'
 import { QueryHistoryPanel } from './components/QueryHistory/QueryHistoryPanel'
 import { EditorTab } from './components/QueryEditor/EditorTab'
@@ -11,6 +12,8 @@ import { QueryResultPanel } from './components/ResultsPanel/QueryResultPanel'
 import { StatusBar } from './components/StatusBar/StatusBar'
 import { ConnectionDialog } from './components/Dialogs/ConnectionDialog'
 import { SettingsDialog } from './components/Dialogs/SettingsDialog'
+import { SaveQueryDialog } from './components/Dialogs/SaveQueryDialog'
+import { ConfirmSaveChangesDialog } from './components/Dialogs/ConfirmSaveChangesDialog'
 import { CommandPalette } from './components/CommandPalette/CommandPalette'
 import { Toaster } from './components/ui/toaster'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from './components/ui/resizable'
@@ -18,7 +21,7 @@ import { TooltipProvider } from './components/ui/tooltip'
 import { initAnalytics, setAnalyticsEnabled, trackEvent } from './lib/analytics'
 
 export default function App(): JSX.Element {
-  const { theme, setTheme, setUpdaterState, openSettings, loadSettings, loadConnections, restoreSession, historyPanelOpen } =
+  const { theme, setTheme, setUpdaterState, openSettings, loadSettings, loadConnections, loadSavedQueries, restoreSession, historyPanelOpen } =
     useAppStore()
 
   const inspectedRow = useAppStore((s) => s.inspectedRow)
@@ -47,6 +50,7 @@ export default function App(): JSX.Element {
     ;(async () => {
       await loadSettings()
       await loadConnections()
+      if (window.api.savedQueries) await loadSavedQueries()
       await restoreSession()
       const settings = await window.api.settings.get()
       initAnalytics(settings.analyticsEnabled)
@@ -122,6 +126,7 @@ export default function App(): JSX.Element {
           >
             <ConnectionList />
             <SchemaTree />
+            <SavedQueriesPanel />
           </ResizablePanel>
 
           <ResizableHandle />
@@ -158,6 +163,8 @@ export default function App(): JSX.Element {
         <StatusBar />
         <ConnectionDialog />
         <SettingsDialog />
+        <SaveQueryDialog />
+        <ConfirmSaveChangesDialog />
         <CommandPalette />
         <Toaster />
       </div>

--- a/src/renderer/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Command } from 'cmdk'
 import { useAppStore } from '../../store/useAppStore'
-import { Table2, Eye, Columns, PlugZap, Plus, Loader2, ChevronDown, Check } from 'lucide-react'
+import { Table2, Eye, Columns, PlugZap, Plus, Loader2, ChevronDown, Check, Bookmark } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import type { TableInfo, ColumnInfo } from '../../types'
 
@@ -22,11 +22,13 @@ export function CommandPalette(): JSX.Element {
     connectedIds,
     connections,
     schemaStates,
+    savedQueries,
     openTableBrowser,
     openConnectionDialog,
     connectToDb,
     setActiveConnection,
     loadTables,
+    openSavedQueryInEditor,
   } = useAppStore()
 
   const [connectingId, setConnectingId] = useState<string | null>(null)
@@ -111,6 +113,10 @@ export function CommandPalette(): JSX.Element {
   const isSearching = search.trim().length > 0
   const visibleTables = (isSearching || showAllTables) ? allTables : allTables.slice(0, TABLE_PREVIEW_COUNT)
   const hasMoreTables = !isSearching && allTables.length > TABLE_PREVIEW_COUNT
+
+  const visibleSavedQueries = activeConnectionId
+    ? savedQueries.filter((q) => q.connectionId === activeConnectionId || q.connectionId === null)
+    : savedQueries
 
   const handleSelectTable = (schema: string, table: string): void => {
     if (!activeConnectionId) return
@@ -242,7 +248,27 @@ export function CommandPalette(): JSX.Element {
           </Command.Group>
         )}
 
-        {(isConnected && (allTables.length > 0 || allColumns.length > 0)) && (
+        {/* Saved Queries — when connected */}
+        {isConnected && visibleSavedQueries.length > 0 && (
+          <Command.Group heading="Saved Queries">
+            {visibleSavedQueries.map((q) => (
+              <Command.Item
+                key={q.id}
+                value={q.name}
+                onSelect={() => {
+                  openSavedQueryInEditor(q.sql, q.id, q.name)
+                  closeCommandPalette()
+                }}
+                className={ITEM_CLASS}
+              >
+                <Bookmark className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{q.name}</span>
+              </Command.Item>
+            ))}
+          </Command.Group>
+        )}
+
+        {(isConnected && (allTables.length > 0 || allColumns.length > 0 || visibleSavedQueries.length > 0)) && (
           <Command.Separator className="-mx-2 my-1 h-px bg-border" alwaysRender />
         )}
 

--- a/src/renderer/src/components/Dialogs/ConfirmSaveChangesDialog.tsx
+++ b/src/renderer/src/components/Dialogs/ConfirmSaveChangesDialog.tsx
@@ -28,6 +28,9 @@ export function ConfirmSaveChangesDialog(): JSX.Element {
     setSaving(true)
     try {
       await confirmSaveChanges()
+    } catch (err) {
+      console.error('[ConfirmSaveChanges] confirmSaveChanges failed:', err)
+      throw err
     } finally {
       setSaving(false)
     }

--- a/src/renderer/src/components/Dialogs/ConfirmSaveChangesDialog.tsx
+++ b/src/renderer/src/components/Dialogs/ConfirmSaveChangesDialog.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react'
+import { useAppStore } from '../../store/useAppStore'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '../ui/dialog'
+import { Button } from '../ui/button'
+import { Loader2 } from 'lucide-react'
+
+export function ConfirmSaveChangesDialog(): JSX.Element {
+  const {
+    saveChangesConfirmOpen,
+    saveChangesConfirmPayload,
+    savedQueries,
+    closeSaveChangesConfirm,
+    confirmSaveChanges
+  } = useAppStore()
+
+  const [saving, setSaving] = useState(false)
+  const saved = saveChangesConfirmPayload
+    ? savedQueries.find((q) => q.id === saveChangesConfirmPayload.savedQueryId)
+    : null
+
+  const handleConfirm = async (): Promise<void> => {
+    setSaving(true)
+    try {
+      await confirmSaveChanges()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={saveChangesConfirmOpen} onOpenChange={(o) => !o && closeSaveChangesConfirm()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Save changes</DialogTitle>
+          <DialogDescription>
+            Save changes to <strong>{saved?.name ?? 'this query'}</strong>?
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={closeSaveChangesConfirm}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={saving}>
+            {saving && <Loader2 className="mr-2 h-3 w-3 animate-spin" />}
+            Save
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/Dialogs/SaveQueryDialog.tsx
+++ b/src/renderer/src/components/Dialogs/SaveQueryDialog.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react'
+import { useAppStore } from '../../store/useAppStore'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '../ui/dialog'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Loader2 } from 'lucide-react'
+
+export function SaveQueryDialog(): JSX.Element {
+  const {
+    saveQueryDialogOpen,
+    editingSavedQueryId,
+    saveQueryInitialSql,
+    savedQueries,
+    closeSaveQueryDialog,
+    saveSavedQuery,
+    activeConnectionId
+  } = useAppStore()
+
+  const editing = editingSavedQueryId
+    ? savedQueries.find((q) => q.id === editingSavedQueryId)
+    : null
+
+  const [name, setName] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (saveQueryDialogOpen) {
+      setName(editing?.name ?? '')
+    }
+  }, [saveQueryDialogOpen, editing?.name])
+
+  const handleSave = async (): Promise<void> => {
+    const sql = saveQueryInitialSql
+    if (!name.trim()) return
+    if (!sql.trim()) return
+
+    setSaving(true)
+    try {
+      await saveSavedQuery({
+        id: editingSavedQueryId ?? undefined,
+        name: name.trim(),
+        sql: sql.trim(),
+        connectionId: activeConnectionId ?? null
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={saveQueryDialogOpen} onOpenChange={(o) => !o && closeSaveQueryDialog()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{editing ? 'Rename Saved Query' : 'Save Query'}</DialogTitle>
+          <DialogDescription>
+            {editing
+              ? 'Change the name for this saved query.'
+              : 'Save the current query for quick access later.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              placeholder="e.g. Active users last 7 days"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={closeSaveQueryDialog}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={saving || !name.trim()}
+          >
+            {saving && <Loader2 className="mr-2 h-3 w-3 animate-spin" />}
+            {editing ? 'Rename' : 'Save'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/Dialogs/SaveQueryDialog.tsx
+++ b/src/renderer/src/components/Dialogs/SaveQueryDialog.tsx
@@ -11,6 +11,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Loader2 } from 'lucide-react'
+import { toast } from '../../hooks/use-toast'
 
 export function SaveQueryDialog(): JSX.Element {
   const {
@@ -48,6 +49,19 @@ export function SaveQueryDialog(): JSX.Element {
         name: name.trim(),
         sql: sql.trim(),
         connectionId: activeConnectionId ?? null
+      })
+    } catch (err) {
+      const safeMessage =
+        err instanceof Error
+          ? err.message
+          : err != null &&
+              typeof (err as { message?: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : String(err ?? 'Unknown error')
+      toast({
+        title: 'Save failed',
+        description: safeMessage,
+        variant: 'destructive'
       })
     } finally {
       setSaving(false)

--- a/src/renderer/src/components/QueryEditor/EditorTab.tsx
+++ b/src/renderer/src/components/QueryEditor/EditorTab.tsx
@@ -8,7 +8,7 @@ import { TableBrowser } from '../ResultsPanel/TableBrowser'
 import { toBucket, trackEvent } from '../../lib/analytics'
 
 export function EditorTab(): JSX.Element {
-  const { tabs, activeTabId, activeConnectionId, connectedIds, updateTab, theme, editorFontSize, openSaveQueryDialog, openSaveChangesConfirm, invalidateTableData } = useAppStore()
+  const { tabs, activeTabId, activeConnectionId, connectedIds, savedQueries, updateTab, theme, editorFontSize, openSaveQueryDialog, openSaveChangesConfirm, invalidateTableData } = useAppStore()
   const activeTab = tabs.find((t) => t.id === activeTabId)
   const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null)
 
@@ -167,6 +167,10 @@ export function EditorTab(): JSX.Element {
 
   if (!activeTab) return <div className="flex-1" />
 
+  const saved = activeTab.savedQueryId ? savedQueries.find((q) => q.id === activeTab.savedQueryId) : null
+  const hasUnsavedChanges = !saved || saved.sql.trim() !== (activeTab.sql ?? '').trim()
+  const showSaveButton = hasUnsavedChanges
+
   if (activeTab.mode === 'table' && activeTab.tableMeta) {
     return <TableBrowser tab={activeTab} />
   }
@@ -178,16 +182,18 @@ export function EditorTab(): JSX.Element {
           {isConnected ? `Connected` : 'No connection — select one from the sidebar'}
         </span>
         <div className="flex items-center gap-1.5">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={handleSaveQuery}
-            className="h-6 gap-1.5 text-xs"
-            title="Save query"
-          >
-            <BookmarkPlus className="h-3 w-3" />
-            Save
-          </Button>
+          {showSaveButton && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleSaveQuery}
+              className="h-6 gap-1.5 text-xs"
+              title="Save query"
+            >
+              <BookmarkPlus className="h-3 w-3" />
+              Save
+            </Button>
+          )}
           <Button
             size="sm"
             onClick={handleRun}

--- a/src/renderer/src/components/QueryEditor/EditorTab.tsx
+++ b/src/renderer/src/components/QueryEditor/EditorTab.tsx
@@ -3,12 +3,12 @@ import Editor, { type OnMount } from '@monaco-editor/react'
 import type * as Monaco from 'monaco-editor'
 import { useAppStore } from '../../store/useAppStore'
 import { Button } from '../ui/button'
-import { Play, Loader2 } from 'lucide-react'
+import { Play, Loader2, BookmarkPlus } from 'lucide-react'
 import { TableBrowser } from '../ResultsPanel/TableBrowser'
 import { toBucket, trackEvent } from '../../lib/analytics'
 
 export function EditorTab(): JSX.Element {
-  const { tabs, activeTabId, activeConnectionId, connectedIds, updateTab, theme, editorFontSize } = useAppStore()
+  const { tabs, activeTabId, activeConnectionId, connectedIds, updateTab, theme, editorFontSize, openSaveQueryDialog, openSaveChangesConfirm, invalidateTableData } = useAppStore()
   const activeTab = tabs.find((t) => t.id === activeTabId)
   const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null)
 
@@ -139,6 +139,10 @@ export function EditorTab(): JSX.Element {
         durationMs: result.durationMs,
         rowCount: result.rowCount
       })
+      const mutateCommands = ['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE']
+      if (mutateCommands.includes(result.command)) {
+        invalidateTableData(activeConnectionId)
+      }
     } catch (err) {
       trackEvent('query_executed', {
         success: false
@@ -148,7 +152,18 @@ export function EditorTab(): JSX.Element {
         isLoading: false
       })
     }
-  }, [activeTabId, activeConnectionId, isConnected, updateTab])
+  }, [activeTabId, activeConnectionId, isConnected, updateTab, invalidateTableData])
+
+  const handleSaveQuery = useCallback(() => {
+    const editor = editorRef.current
+    const model = editor?.getModel()
+    const sql = model ? model.getValue() : (activeTab?.sql ?? '')
+    if (activeTab?.savedQueryId) {
+      openSaveChangesConfirm(activeTab.savedQueryId, sql)
+    } else {
+      openSaveQueryDialog(sql)
+    }
+  }, [activeTab?.sql, activeTab?.savedQueryId, openSaveQueryDialog, openSaveChangesConfirm])
 
   if (!activeTab) return <div className="flex-1" />
 
@@ -162,22 +177,34 @@ export function EditorTab(): JSX.Element {
         <span className="text-xs text-muted-foreground">
           {isConnected ? `Connected` : 'No connection — select one from the sidebar'}
         </span>
-        <Button
-          size="sm"
-          onClick={handleRun}
-          disabled={!isConnected || activeTab.isLoading}
-          className="h-6 gap-1.5 text-xs"
-        >
+        <div className="flex items-center gap-1.5">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleSaveQuery}
+            className="h-6 gap-1.5 text-xs"
+            title="Save query"
+          >
+            <BookmarkPlus className="h-3 w-3" />
+            Save
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleRun}
+            disabled={!isConnected || activeTab.isLoading}
+            className="h-6 gap-1.5 text-xs"
+          >
           {activeTab.isLoading ? (
             <Loader2 className="h-3 w-3 animate-spin" />
           ) : (
             <Play className="h-3 w-3" />
           )}
-          Run
-          <kbd className="ml-1 hidden rounded bg-primary-foreground/20 px-1 text-2xs opacity-70 sm:inline">
-            ⌘↵
-          </kbd>
-        </Button>
+            Run
+            <kbd className="ml-1 hidden rounded bg-primary-foreground/20 px-1 text-2xs opacity-70 sm:inline">
+              ⌘↵
+            </kbd>
+          </Button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-hidden">

--- a/src/renderer/src/components/QueryHistory/QueryHistoryPanel.tsx
+++ b/src/renderer/src/components/QueryHistory/QueryHistoryPanel.tsx
@@ -24,7 +24,7 @@ export function QueryHistoryPanel(): JSX.Element {
   const handleRestore = (entry: QueryHistoryEntry): void => {
     const activeTab = tabs.find((t) => t.id === activeTabId)
     if (activeTab && activeTab.mode === 'query') {
-      updateTab(activeTab.id, { sql: entry.sql })
+      updateTab(activeTab.id, { sql: entry.sql, savedQueryId: null })
     } else {
       addTab({ sql: entry.sql, title: 'Query', mode: 'query' })
     }

--- a/src/renderer/src/components/ResultsPanel/TableBrowser.tsx
+++ b/src/renderer/src/components/ResultsPanel/TableBrowser.tsx
@@ -27,7 +27,7 @@ type FilterMode = 'query' | 'search'
 const PAGE_SIZE = 200
 
 export function TableBrowser({ tab }: { tab: EditorTab }): JSX.Element {
-  const { updateTab } = useAppStore()
+  const { updateTab, tableInvalidationTrigger } = useAppStore()
   const meta = tab.tableMeta!
 
   const [page, setPage] = useState(0)
@@ -66,6 +66,8 @@ export function TableBrowser({ tab }: { tab: EditorTab }): JSX.Element {
   matchRowsRef.current = matchRows
   const matchIdxRef = useRef(matchIdx)
   matchIdxRef.current = matchIdx
+  const activeFilterRef = useRef(activeFilter)
+  activeFilterRef.current = activeFilter
 
   const fetchPage = useCallback(
     async (pageNum: number, sort: SortState = sortRef.current, filter: string = activeFilter) => {
@@ -102,6 +104,12 @@ export function TableBrowser({ tab }: { tab: EditorTab }): JSX.Element {
   useEffect(() => {
     if (!tab.tableData) fetchPage(0, null, '')
   }, [tab.id])
+
+  useEffect(() => {
+    if (tableInvalidationTrigger.connectionId === meta.connectionId && tableInvalidationTrigger.at > 0) {
+      fetchPage(pageRef.current, sortRef.current, activeFilterRef.current)
+    }
+  }, [tableInvalidationTrigger.at, tableInvalidationTrigger.connectionId, meta.connectionId, fetchPage])
 
   // Clear row selection when switching between tabs (but keep pending edits)
   useEffect(() => {

--- a/src/renderer/src/components/Sidebar/SavedQueriesPanel.tsx
+++ b/src/renderer/src/components/Sidebar/SavedQueriesPanel.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react'
+import { useAppStore } from '../../store/useAppStore'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '../ui/dropdown-menu'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Bookmark, Play, MoreHorizontal, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import type { SavedQuery } from '../../types'
+
+export function SavedQueriesPanel(): JSX.Element {
+  const [collapsed, setCollapsed] = useState(false)
+  const [queryToDelete, setQueryToDelete] = useState<SavedQuery | null>(null)
+  const {
+    savedQueries,
+    loadSavedQueries,
+    openSaveQueryDialog,
+    openSavedQueryInEditor,
+    runSavedQuery,
+    deleteSavedQuery,
+    activeConnectionId,
+    connectedIds
+  } = useAppStore()
+
+  useEffect(() => {
+    if (window.api?.savedQueries) loadSavedQueries()
+  }, [loadSavedQueries])
+
+  const isConnected = activeConnectionId ? connectedIds.includes(activeConnectionId) : false
+
+  const visibleQueries =
+    activeConnectionId
+      ? savedQueries.filter((q) => q.connectionId === activeConnectionId || q.connectionId === null)
+      : savedQueries
+
+  const handleOpenInEditor = (q: SavedQuery): void => {
+    openSavedQueryInEditor(q.sql, q.id, q.name)
+  }
+
+  const handleRun = async (q: SavedQuery): Promise<void> => {
+    if (!isConnected) return
+    await runSavedQuery(q.sql, q.id, q.name)
+  }
+
+  const handleRename = (q: SavedQuery): void => {
+    openSaveQueryDialog(q.sql, q.id)
+  }
+
+  const handleDeleteClick = (q: SavedQuery): void => {
+    setQueryToDelete(q)
+  }
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    if (!queryToDelete) return
+    await deleteSavedQuery(queryToDelete.id)
+    setQueryToDelete(null)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col border-t border-sidebar-border',
+        collapsed ? 'shrink-0' : 'flex-1 min-h-0'
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex w-full items-center justify-between px-3 py-2 shrink-0 hover:bg-accent/50 transition-colors"
+      >
+        <span className="text-2xs font-semibold uppercase tracking-wider text-sidebar-foreground/50">
+          Saved Queries
+        </span>
+        {collapsed ? (
+          <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        )}
+      </button>
+
+      {!collapsed && (visibleQueries.length === 0 ? (
+        <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+          <Bookmark className="mx-auto mb-2 h-6 w-6 opacity-50" />
+          <p>No saved queries yet.</p>
+          <p className="mt-1">
+            Write a query and click <strong>Save</strong> in the editor toolbar.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-2 pb-2 space-y-0.5">
+          {visibleQueries.map((q) => (
+            <div
+              key={q.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => handleOpenInEditor(q)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  handleOpenInEditor(q)
+                }
+              }}
+              className={cn(
+                'group flex items-center gap-1 rounded-md px-2 py-1.5 cursor-pointer',
+                'hover:bg-accent/50'
+              )}
+              title={q.name}
+            >
+              <span className="flex-1 min-w-0 text-xs truncate">{q.name}</span>
+              <div
+                className="flex shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleRun(q)
+                  }}
+                  disabled={!isConnected}
+                  title="Run"
+                >
+                  <Play className="h-2.5 w-2.5" />
+                </Button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <MoreHorizontal className="h-2.5 w-2.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => handleRename(q)}>
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleDeleteClick(q)}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      <Dialog open={!!queryToDelete} onOpenChange={(open) => !open && setQueryToDelete(null)}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-destructive" />
+              Delete saved query?
+            </DialogTitle>
+            <DialogDescription>
+              "{queryToDelete?.name}" will be permanently deleted. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" size="sm" onClick={() => setQueryToDelete(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleConfirmDelete}>
+              Delete
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/renderer/src/global.d.ts
+++ b/src/renderer/src/global.d.ts
@@ -5,7 +5,8 @@ import type {
   TableData,
   TableInfo,
   ColumnInfo,
-  QueryHistoryEntry
+  QueryHistoryEntry,
+  SavedQuery
 } from './types'
 
 declare global {
@@ -86,6 +87,16 @@ declare global {
         list(connectionId?: string): Promise<QueryHistoryEntry[]>
         clear(connectionId?: string): Promise<void>
       }
+      savedQueries: {
+        list(connectionId?: string | null): Promise<SavedQuery[]>
+        save(payload: {
+          id?: string
+          name: string
+          sql: string
+          connectionId?: string | null
+        }): Promise<SavedQuery>
+        delete(id: string): Promise<void>
+      }
       session: {
         get(): Promise<{
           activeConnectionId: string | null
@@ -97,6 +108,7 @@ declare global {
             mode: 'query' | 'table'
             tableMeta: { schema: string; table: string; connectionId: string } | null
             connectionId: string | null
+            savedQueryId?: string | null
           }[]
         }>
         save(session: {
@@ -109,6 +121,7 @@ declare global {
             mode: 'query' | 'table'
             tableMeta: { schema: string; table: string; connectionId: string } | null
             connectionId: string | null
+            savedQueryId?: string | null
           }[]
         }): Promise<void>
       }

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -13,7 +13,6 @@ export interface EditorTab {
   isLoading: boolean;
   error: string | null;
   connectionId: string | null;
-  /** When set, Save updates this saved query instead of creating a new one */
   savedQueryId?: string | null;
 }
 

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import type { SavedConnection, QueryResult, TableData, TableInfo, ColumnInfo } from "../types";
+import type { SavedConnection, QueryResult, TableData, TableInfo, ColumnInfo, SavedQuery } from "../types";
+import { toast } from "../hooks/use-toast";
 
 export interface EditorTab {
   id: string;
@@ -12,6 +13,8 @@ export interface EditorTab {
   isLoading: boolean;
   error: string | null;
   connectionId: string | null;
+  /** When set, Save updates this saved query instead of creating a new one */
+  savedQueryId?: string | null;
 }
 
 export interface SchemaNode {
@@ -29,6 +32,7 @@ export interface SessionTab {
   mode: "query" | "table";
   tableMeta: { schema: string; table: string; connectionId: string } | null;
   connectionId: string | null;
+  savedQueryId?: string | null;
 }
 
 interface AppState {
@@ -89,6 +93,26 @@ interface AppState {
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
   toggleCommandPalette: () => void;
+
+  savedQueries: SavedQuery[];
+  saveQueryDialogOpen: boolean;
+  editingSavedQueryId: string | null;
+  saveQueryInitialSql: string;
+  saveChangesConfirmOpen: boolean;
+  saveChangesConfirmPayload: { savedQueryId: string; sql: string } | null;
+  loadSavedQueries: () => Promise<void>;
+  saveSavedQuery: (payload: { id?: string; name: string; sql: string; connectionId?: string | null }) => Promise<void>;
+  deleteSavedQuery: (id: string) => Promise<void>;
+  openSaveQueryDialog: (initialSql?: string, editingId?: string | null) => void;
+  closeSaveQueryDialog: () => void;
+  openSaveChangesConfirm: (savedQueryId: string, sql: string) => void;
+  closeSaveChangesConfirm: () => void;
+  confirmSaveChanges: () => Promise<void>;
+  openSavedQueryInEditor: (sql: string, savedQueryId?: string | null, savedQueryName?: string) => void;
+  runSavedQuery: (sql: string, savedQueryId?: string | null, savedQueryName?: string) => Promise<void>;
+  runQueryToActiveTab: () => Promise<void>;
+  tableInvalidationTrigger: { at: number; connectionId: string };
+  invalidateTableData: (connectionId: string) => void;
 
   restoreSession: () => Promise<void>;
   saveSession: () => void;
@@ -400,6 +424,176 @@ export const useAppStore = create<AppState>((set, get) => ({
   closeCommandPalette: () => set({ commandPaletteOpen: false }),
   toggleCommandPalette: () => set((s) => ({ commandPaletteOpen: !s.commandPaletteOpen })),
 
+  savedQueries: [],
+  saveQueryDialogOpen: false,
+  editingSavedQueryId: null,
+  saveQueryInitialSql: "",
+  saveChangesConfirmOpen: false,
+  saveChangesConfirmPayload: null,
+
+  loadSavedQueries: async () => {
+    if (!window.api?.savedQueries) return;
+    try {
+      const queries = await window.api.savedQueries.list();
+      set({ savedQueries: queries });
+    } catch (err) {
+      toast({ title: 'Failed to load saved queries', description: (err as Error).message, variant: 'destructive' });
+    }
+  },
+
+  saveSavedQuery: async (payload) => {
+    if (!window.api?.savedQueries) return;
+    try {
+      const saved = await window.api.savedQueries.save(payload);
+      set((s) => {
+        const tabs = s.tabs.map((t) => {
+          if (payload.id && t.savedQueryId === payload.id) {
+            return { ...t, title: saved.name };
+          }
+          if (!payload.id && t.id === s.activeTabId) {
+            return { ...t, savedQueryId: saved.id, title: saved.name };
+          }
+          return t;
+        });
+        return {
+          savedQueries: payload.id
+            ? s.savedQueries.map((q) => (q.id === payload.id ? saved : q))
+            : [saved, ...s.savedQueries.filter((q) => q.id !== saved.id)],
+          tabs,
+          saveQueryDialogOpen: false,
+          editingSavedQueryId: null,
+          saveQueryInitialSql: "",
+        };
+      });
+    } catch (err) {
+      toast({ title: 'Save failed', description: (err as Error).message, variant: 'destructive' });
+    }
+  },
+
+  deleteSavedQuery: async (id) => {
+    if (!window.api?.savedQueries) return;
+    try {
+      await window.api.savedQueries.delete(id);
+      set((s) => ({
+        savedQueries: s.savedQueries.filter((q) => q.id !== id),
+        tabs: s.tabs.map((t) =>
+          t.savedQueryId === id ? { ...t, savedQueryId: null } : t
+        ),
+      }));
+    } catch (err) {
+      toast({ title: 'Delete failed', description: (err as Error).message, variant: 'destructive' });
+    }
+  },
+
+  openSaveQueryDialog: (initialSql = "", editingId = null) => {
+    set({
+      saveQueryDialogOpen: true,
+      editingSavedQueryId: editingId,
+      saveQueryInitialSql: initialSql,
+    });
+  },
+
+  closeSaveQueryDialog: () => {
+    set({ saveQueryDialogOpen: false, editingSavedQueryId: null, saveQueryInitialSql: "" });
+  },
+
+  openSaveChangesConfirm: (savedQueryId, sql) => {
+    set({ saveChangesConfirmOpen: true, saveChangesConfirmPayload: { savedQueryId, sql } });
+  },
+
+  closeSaveChangesConfirm: () => {
+    set({ saveChangesConfirmOpen: false, saveChangesConfirmPayload: null });
+  },
+
+  confirmSaveChanges: async () => {
+    const payload = get().saveChangesConfirmPayload;
+    if (!payload || !window.api?.savedQueries) return;
+    const saved = get().savedQueries.find((q) => q.id === payload.savedQueryId);
+    if (!saved) {
+      set({ saveChangesConfirmOpen: false, saveChangesConfirmPayload: null });
+      toast({ title: 'Query was deleted', description: 'The saved query no longer exists.', variant: 'destructive' });
+      return;
+    }
+    await get().saveSavedQuery({
+      id: payload.savedQueryId,
+      name: saved.name,
+      sql: payload.sql.trim(),
+      connectionId: get().activeConnectionId ?? null
+    });
+    set({ saveChangesConfirmOpen: false, saveChangesConfirmPayload: null });
+  },
+
+  openSavedQueryInEditor: (sql, savedQueryId, savedQueryName) => {
+    const { tabs, addTab, setActiveTab } = get();
+    const existingTab = savedQueryId ? tabs.find((t) => t.savedQueryId === savedQueryId) : null;
+    if (existingTab) {
+      setActiveTab(existingTab.id);
+    } else {
+      const tabId = addTab({
+        sql,
+        savedQueryId: savedQueryId ?? null,
+        mode: 'query' as const,
+        title: savedQueryName ?? 'Query'
+      });
+      setActiveTab(tabId);
+    }
+  },
+
+  runSavedQuery: async (sql, _savedQueryId, _savedQueryName) => {
+    const { activeConnectionId, connectedIds, invalidateTableData } = get();
+    if (!activeConnectionId || !connectedIds.includes(activeConnectionId)) return;
+    const trimmed = sql.trim();
+    if (!trimmed) return;
+    try {
+      const result = await window.api.query.execute(activeConnectionId, trimmed);
+      await window.api.history.add({
+        connectionId: activeConnectionId,
+        sql: trimmed,
+        executedAt: Date.now(),
+        durationMs: result.durationMs,
+        rowCount: result.rowCount
+      });
+      const mutateCommands = ['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE'];
+      if (mutateCommands.includes(result.command)) {
+        invalidateTableData(activeConnectionId);
+      }
+      toast({ title: 'Query ran', description: `${result.rowCount ?? 0} row${(result.rowCount ?? 0) !== 1 ? 's' : ''} affected` });
+    } catch (err) {
+      toast({ title: 'Query failed', description: (err as Error).message, variant: 'destructive' });
+    }
+  },
+
+  runQueryToActiveTab: async () => {
+    const { activeTabId, activeConnectionId, connectedIds, tabs, updateTab } = get();
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || !activeConnectionId || !connectedIds.includes(activeConnectionId)) return;
+    const sql = tab.sql.trim();
+    if (!sql) return;
+    updateTab(activeTabId!, { isLoading: true, error: null, result: null });
+    try {
+      const result = await window.api.query.execute(activeConnectionId, sql);
+      updateTab(activeTabId!, { result, isLoading: false });
+      await window.api.history.add({
+        connectionId: activeConnectionId,
+        sql,
+        executedAt: Date.now(),
+        durationMs: result.durationMs,
+        rowCount: result.rowCount,
+      });
+      const mutateCommands = ['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE'];
+      if (mutateCommands.includes(result.command)) {
+        get().invalidateTableData(activeConnectionId);
+      }
+    } catch (err) {
+      updateTab(activeTabId!, { error: (err as Error).message, isLoading: false });
+    }
+  },
+
+  tableInvalidationTrigger: { at: 0, connectionId: '' },
+  invalidateTableData: (connectionId) => {
+    set({ tableInvalidationTrigger: { at: Date.now(), connectionId } });
+  },
+
   restoreSession: async () => {
     if (!window.api?.session) return;
     const session = await window.api.session.get();
@@ -419,18 +613,24 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     // Now restore tabs — table browsers will mount and fetch against
     // the already-live connection.
-    const restoredTabs: EditorTab[] = session.tabs.map((st: SessionTab) => ({
-      id: st.id,
-      title: st.title,
-      sql: st.sql,
-      result: null,
-      tableData: null,
-      mode: st.mode,
-      tableMeta: st.tableMeta,
-      isLoading: false,
-      error: null,
-      connectionId: st.connectionId,
-    }));
+    const savedQueryIds = new Set(get().savedQueries.map((q) => q.id));
+    const restoredTabs: EditorTab[] = session.tabs.map((st: SessionTab) => {
+      const savedQueryId = st.savedQueryId ?? null;
+      const orphaned = savedQueryId != null && !savedQueryIds.has(savedQueryId);
+      return {
+        id: st.id,
+        title: st.title,
+        sql: st.sql,
+        result: null,
+        tableData: null,
+        mode: st.mode,
+        tableMeta: st.tableMeta,
+        isLoading: false,
+        error: null,
+        connectionId: st.connectionId,
+        savedQueryId: orphaned ? null : savedQueryId,
+      };
+    });
 
     set({
       tabs: restoredTabs,
@@ -448,6 +648,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       mode: t.mode,
       tableMeta: t.tableMeta,
       connectionId: t.connectionId,
+      savedQueryId: t.savedQueryId ?? null,
     }));
     window.api.session.save({
       activeConnectionId,

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -497,6 +497,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   openSaveChangesConfirm: (savedQueryId, sql) => {
+    const saved = get().savedQueries.find((q) => q.id === savedQueryId);
+    if (saved && saved.sql.trim() === sql.trim()) return;
     set({ saveChangesConfirmOpen: true, saveChangesConfirmPayload: { savedQueryId, sql } });
   },
 

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -67,3 +67,12 @@ export interface QueryHistoryEntry {
   durationMs?: number
   rowCount?: number
 }
+
+export interface SavedQuery {
+  id: string
+  name: string
+  sql: string
+  connectionId: string | null
+  createdAt: number
+  updatedAt: number
+}


### PR DESCRIPTION
PR introduces:

- Save, rename, and delete queries with names; stored in electron-store
- Saved Queries panel in the sidebar: list, run, open in editor
- Save button in the editor toolbar that only shows when there are unsaved changes (hidden for saved queries with no edits)
- Confirm-save dialog only shown when the editor SQL differs from the saved query
- Command palette integration: search and open saved queries